### PR TITLE
feat: axios 설정 유지

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { userInfoGetApi } from "./util/Axios";
+import { userInfoGetApi, setAxiosAuthorization } from "./util/Axios";
 import { useDispatch } from "react-redux";
 import { setTokenInfo, setUserInfo } from "./redux/auth-reducer";
 
@@ -19,6 +19,7 @@ const Auth = () => {
       ),
     };
 
+    setAxiosAuthorization(tokenInfo.accessToken);
     localStorage.setItem("tokenInfo", JSON.stringify(tokenInfo));
 
     try {

--- a/src/util/Axios.js
+++ b/src/util/Axios.js
@@ -1,17 +1,14 @@
 import axios from "axios";
-
+import { loadAccessToken } from "./storage";
 const baseURL = "https://test.chll.it";
 
-export const Axios = axios.create({
-  baseURL,
-});
+axios.defaults.baseURL = baseURL;
+axios.defaults.headers.common['Authorization'] = `Bearer ${loadAccessToken()}`;
+
+export const setAxiosAuthorization = (accessToken) => {
+  axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+}
 
 export const userInfoGetApi = async () => {
-  return Axios.get("/v1/user", {
-    headers: {
-      Authorization: `Bearer ${
-        JSON.parse(localStorage.getItem("tokenInfo")).accessToken
-      }`,
-    },
-  });
+  return axios.get("/v1/user");
 };

--- a/src/util/storage.js
+++ b/src/util/storage.js
@@ -7,6 +7,8 @@ export const storageState = (storageKey, predefined) => {
     return predefined;
 }
 
+export const loadAccessToken = () => storageState("tokenInfo", { accessToken: null }).accessToken;
+
 export const removeTokenInfo = () => {
     localStorage.removeItem("tokenInfo");
 }


### PR DESCRIPTION
이런 방식은 어떤가요?

기존 방식은 매 요청마다 인스턴스를 새로 생성하게 되어 `localStorage.getItem()`과 `JSON.parse()`를 수행하였습니다.
제안하는 방식은 처음 로드시 딱 한번만 설정되며, 그 다음부터는 미리 설정된 axios instance를 이용하게 됩니다.
`navigate()`, `UserInfoGetApi()` 시에도 설정을 다시 로드하지 않습니다.